### PR TITLE
Use `as_label()` for titles

### DIFF
--- a/R/geom-heat-circle.R
+++ b/R/geom-heat-circle.R
@@ -90,13 +90,13 @@ geom_heat_circle <- function(outside,
 
   list(geom_circle_outside(ggplot2::aes(fill = {{ outside }})),
 
-       ggplot2::scale_fill_gradientn(outside_name, colors = outside_colors, ...),
+       ggplot2::scale_fill_gradientn(rlang::as_label(outside_name), colors = outside_colors, ...),
 
        ggnewscale::new_scale_fill(),
 
        geom_circle_inside(ggplot2::aes(fill = {{ inside }}, r = r)),
 
-       ggplot2::scale_fill_gradientn(inside_name, colors = inside_colors, ...))
+       ggplot2::scale_fill_gradientn(rlang::as_label(inside_name), colors = inside_colors, ...))
 
 }
 

--- a/R/geom-heat-grid.R
+++ b/R/geom-heat-grid.R
@@ -90,13 +90,13 @@ geom_heat_grid <- function(outside,
 
   list(geom_tile_outside(ggplot2::aes(fill = {{ outside }})),
 
-       ggplot2::scale_fill_gradientn(outside_name, colors = outside_colors, ...),
+       ggplot2::scale_fill_gradientn(rlang::as_label(outside_name), colors = outside_colors, ...),
 
        ggnewscale::new_scale_fill(),
 
        geom_tile_inside(ggplot2::aes(fill = {{ inside }}, r = r)),
 
-       ggplot2::scale_fill_gradientn(inside_name, colors = inside_colors, ...))
+       ggplot2::scale_fill_gradientn(rlang::as_label(inside_name), colors = inside_colors, ...))
 
 }
 

--- a/R/geom-heat-tri.R
+++ b/R/geom-heat-tri.R
@@ -75,13 +75,13 @@ geom_heat_tri <- function(lower,
 
   list(geom_lower_tri(ggplot2::aes(fill = {{ lower }})),
 
-       ggplot2::scale_fill_gradientn(lower_name, colors = lower_colors, ...),
+       ggplot2::scale_fill_gradientn(rlang::as_label(lower_name), colors = lower_colors, ...),
 
        ggnewscale::new_scale_fill(),
 
        geom_upper_tri(ggplot2::aes(fill = {{ upper }})),
 
-       ggplot2::scale_fill_gradientn(upper_name, colors = upper_colors, ...))
+       ggplot2::scale_fill_gradientn(rlang::as_label(upper_name), colors = upper_colors, ...))
 
 }
 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We found that objects of the incorrect type were passed to scale titles, so the solution would be to ensure the objects have the correct type.
This PR uses `as_label()` to cast the expressions to characters.
I couldn't verify the correct working of the package because there are no tests, but at least this PR makes the package compatible with the new ggplot2 version.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun